### PR TITLE
feature: project statuses + new sorting projects

### DIFF
--- a/src/components/project/models/ProjectModel.ts
+++ b/src/components/project/models/ProjectModel.ts
@@ -45,6 +45,18 @@ export interface FullProjectModel {
 
 // TODO: Get rid of this: is state being manipulated? will this be sent to the backend and be saved?
 // If the project.endDate changes, is this also updated?
+
+export enum PROJECT_STATUSES {
+  ACTIVE= 'ACTIVE',
+  NOT_ACTIVE_ANYMORE= 'NOT_ACTIVE_ANYMORE',
+  NOT_YET_ACTIVE= 'NOT_YET_ACTIVE',
+}
+
+export interface IProjectStatuses {
+  ACTIVE: string;
+  NOT_ACTIVE_ANYMORE: string;
+  NOT_YET_ACTIVE: string;
+}
 export interface ProjectDetailsModel extends ProjectModel {
-  active: boolean;
+  status: keyof IProjectStatuses
 }

--- a/src/components/project/models/getProjectFeature.tsx
+++ b/src/components/project/models/getProjectFeature.tsx
@@ -39,8 +39,8 @@ const fullProjectSearch = (filters: ProjectListFilters, prj: FullProjectModel) =
 
 const getRowBackgroundColor = (prj: FullProjectModel): undefined | string => {
   const projectDetails = prj.details;
-  const ONE_MONTH = 1;
-  const THREE_MONTHS = 3;
+  const MONTHS_BEFORE_WARNING = 1;
+  const MONTHS_BEFORE_INFO = 3;
 
   if (projectDetails.status === PROJECT_STATUSES.NOT_YET_ACTIVE) {
     return 'table-success';
@@ -53,10 +53,10 @@ const getRowBackgroundColor = (prj: FullProjectModel): undefined | string => {
   if (projectDetails.endDate) {
     const monthsLeft = moment(projectDetails.endDate).diff(moment(), 'months', true);
 
-    if (monthsLeft < ONE_MONTH) {
+    if (monthsLeft < MONTHS_BEFORE_WARNING) {
       return 'table-warning';
     }
-    if (monthsLeft < THREE_MONTHS) {
+    if (monthsLeft < MONTHS_BEFORE_INFO) {
       return 'table-info';
     }
   }

--- a/src/components/project/models/getProjectFeature.tsx
+++ b/src/components/project/models/getProjectFeature.tsx
@@ -5,7 +5,7 @@ import {Link} from 'react-router-dom';
 import {IList, IListCell, ProjectListFilters} from '../../controls/table/table-models';
 import {IFeature, IFeatureBuilderConfig} from '../../controls/feature/feature-models';
 import {features} from '../../../trans';
-import {FullProjectModel, ProjectClientModel} from './ProjectModel';
+import {FullProjectModel, ProjectClientModel, PROJECT_STATUSES} from './ProjectModel';
 import {t, formatDate, tariffFormat, searchinize} from '../../utils';
 import {EditIcon} from '../../controls/Icon';
 import {InvoiceClientCell} from '../../invoice/invoice-table/InvoiceClientCell';
@@ -18,7 +18,7 @@ export type ProjectFeatureBuilderConfig = IFeatureBuilderConfig<FullProjectModel
 const fullProjectSearch = (filters: ProjectListFilters, prj: FullProjectModel) => {
   const {consultant, partner, client, details} = prj;
 
-  if (!filters.showInactive && !details.active) {
+  if (!filters.showInactive && details.status === PROJECT_STATUSES.NOT_ACTIVE_ANYMORE) {
     return false;
   }
 
@@ -39,17 +39,24 @@ const fullProjectSearch = (filters: ProjectListFilters, prj: FullProjectModel) =
 
 const getRowBackgroundColor = (prj: FullProjectModel): undefined | string => {
   const projectDetails = prj.details;
-  if (!prj.details.active) {
+  const ONE_MONTH = 1;
+  const THREE_MONTHS = 3;
+
+  if (projectDetails.status === PROJECT_STATUSES.NOT_YET_ACTIVE) {
+    return 'table-success';
+  }
+
+  if (projectDetails.status === PROJECT_STATUSES.NOT_ACTIVE_ANYMORE) {
     return 'table-danger';
   }
 
   if (projectDetails.endDate) {
     const monthsLeft = moment(projectDetails.endDate).diff(moment(), 'months', true);
 
-    if (monthsLeft < 1) {
+    if (monthsLeft < ONE_MONTH) {
       return 'table-warning';
     }
-    if (monthsLeft < 3) {
+    if (monthsLeft < THREE_MONTHS) {
       return 'table-info';
     }
   }
@@ -132,6 +139,11 @@ const projectListConfig = (config: ProjectFeatureBuilderConfig): IList<FullProje
       if (!b.details.endDate) {
         return -1;
       }
+
+      if (a.details.endDate.valueOf() === b.details.endDate.valueOf()) {
+        return a.details.startDate.valueOf() - b.details.startDate.valueOf();
+      }
+
       return a.details.endDate.valueOf() - b.details.endDate.valueOf();
     },
   };

--- a/src/components/project/models/getProjectFeature.tsx
+++ b/src/components/project/models/getProjectFeature.tsx
@@ -133,11 +133,8 @@ const projectListConfig = (config: ProjectFeatureBuilderConfig): IList<FullProje
     },
     data: config.data,
     sorter: (a, b) => {
-      if (!a.details.endDate) {
-        return 1;
-      }
-      if (!b.details.endDate) {
-        return -1;
+      if (!a.details.endDate || !b.details.endDate) {
+        return a.details.startDate.valueOf() - b.details.startDate.valueOf();
       }
 
       if (a.details.endDate.valueOf() === b.details.endDate.valueOf()) {


### PR DESCRIPTION
Implemented statuses for a project, it can have 3 modes:
- ACTIVE
- NOT_YET_ACTIVE
- NOT_ACTIVE_ANYMORE

The active property was confusing, because it could hold only 2 states (true/false) while there are actually 3 states.

e.g. A project that was not active YET should NOT be seen as an active project but must be displayed when the show inactive projects toggle is false.

What do you think? Any feedback?